### PR TITLE
Fixes bug in progress widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "automakemkv"
-version = "3.3.0"
+version = "3.3.1"
 description = "Package for automagically ripping media with MakeMKV"
 readme = "README.md"
 authors = [

--- a/src/automakemkv/ui/progress.py
+++ b/src/automakemkv/ui/progress.py
@@ -272,7 +272,7 @@ class BasicProgressWidget(QtWidgets.QWidget):
             return
 
         text = []
-        if elapsed >= 10:
+        if elapsed >= 10 and frac > 0:
             remain = timedelta(
                 seconds=round(
                     (elapsed / frac) - elapsed


### PR DESCRIPTION
There was a bug where the 'frac' variable could be zero, causing a divide error and crashing the program. Have add check for frac > 0 in the if-statement to ensure this doesn't happen in the future.