### PR TITLE
Fix for QThread progress kill

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "automakemkv"
-version = "3.28.0"
+version = "3.29.0"
 description = "Package for automagically ripping media with MakeMKV"
 readme = "README.md"
 authors = [

--- a/src/automakemkv/ui/metadata.py
+++ b/src/automakemkv/ui/metadata.py
@@ -348,6 +348,7 @@ class DiscMetadataEditor(dialogs.MyQDialog):
         # Remove the progress widget from the window if exists
         if self.progress is not None:
             self.layout().removeWidget(self.progress)
+            self.progress.wait()
             self.progress.deleteLater()
             self.progress = None
 

--- a/src/automakemkv/utils.py
+++ b/src/automakemkv/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import time
@@ -51,6 +52,7 @@ class DevToMount(QtCore.QThread):
     ):
         super().__init__()
 
+        self.log = logging.getLogger(__name__)
         self.dev = dev
         self.root = root
         self.uname = os.getlogin()
@@ -66,17 +68,23 @@ class DevToMount(QtCore.QThread):
         if sys.platform.startswith('win'):
             return self.dev
 
-        t0 = time.monotonic()
-        t1 = t0 + TIMEOUT
+        t1 = time.monotonic() + TIMEOUT
+        self.log.debug(
+            "%s - Looking for mount point in: %s",
+            self.dev,
+            self.root,
+        )
 
         # While we have not timed out
         while time.monotonic() < t1:
             path = self.iter_items()
             if path is not None:
+                self.log.debug("%s - Found path: %s", self.dev, path)
                 return path
 
             time.sleep(3.0)
 
+        self.log.debug("%s - Failed to find mount point", self.dev)
         return None
 
     def iter_items(self) -> str | None:


### PR DESCRIPTION
Bug in the Metadata editor where cleaned up the BasicProgressWidget before its QThread was fully done. Overloaded the wait() method of the ProgressParser thread to just 'forget' the subprocess it was parsing and then call super().wait().

Have also added a wait() method to the BasicProgessWidget what waits for the parser thread. This method is now called in the metadata editor before cleaning up